### PR TITLE
Fix endpoint response format / aql query linting issue

### DIFF
--- a/src/service/comment/controller.py
+++ b/src/service/comment/controller.py
@@ -6,7 +6,7 @@ from ..queries import insert_comment, query_event_comments
 
 
 def resolve_get_event_comments(event_id: int) -> List[Dict]:
-    return {"data": [comment.to_dict() for comment in query_event_comments(event_id)]}
+    return [comment.to_dict() for comment in query_event_comments(event_id)]
 
 
 def resolve_post_comment():

--- a/src/service/events/views.py
+++ b/src/service/events/views.py
@@ -42,4 +42,4 @@ def add_attendance():
 @jwt_required()
 @handle_response
 def add_attendance_by_event(event_id: int):
-    return {"data": resolve_get_event_attendance(event_id)}
+    return resolve_get_event_attendance(event_id)

--- a/src/service/queries/comment_queries.py
+++ b/src/service/queries/comment_queries.py
@@ -12,4 +12,4 @@ def insert_comment(attributes: Dict) -> "Comment":
 
 
 def query_event_comments(event_id: int) -> List[Comment]:
-    return Comment.query.filter(Comment.event_id == event_id).filter(Comment.public is False).all()
+    return Comment.query.filter(Comment.event_id == event_id).filter_by(public=False).all()


### PR DESCRIPTION
# Description
Flask sqlalchemy orm does not perform as expected when you use `is` is a query with boolean values. Since linting complains about using `==` operator switching to `filter_by()` instead of `filter()`.
Fixing endpint response.

#### Testing
Locally:
Dev env: 


# Testing guide


# Related pull requests
